### PR TITLE
Fixed booting from mmc in 4.15+

### DIFF
--- a/linux-jwrdegoede/PKGBUILD
+++ b/linux-jwrdegoede/PKGBUILD
@@ -43,8 +43,10 @@ prepare() {
 
   # Hans's config is already in ./.config, so the next line isnt't needed:
   # cat "${srcdir}/config.${CARCH}" > ./.config
-  # Also, there is no usb storage support, so:
+  # Also, there is no usb storage support AND libertas is needed for mmc booting, so:
   cat >> ./.config << EOL
+CONFIG_LIBERTAS=y
+CONFIG_LIBERTAS_SDIO=y
 CONFIG_BLK_CGROUP=y
 CONFIG_BLK_DEV_INITRD=y
 CONFIG_BLK_SCSI_REQUEST=y

--- a/linux-jwrdegoede/PKGBUILD
+++ b/linux-jwrdegoede/PKGBUILD
@@ -43,10 +43,13 @@ prepare() {
 
   # Hans's config is already in ./.config, so the next line isnt't needed:
   # cat "${srcdir}/config.${CARCH}" > ./.config
-  # Also, there is no usb storage support AND libertas is needed for mmc booting, so:
+  # - Building in USB storage support (instead of modules)
+  # - Building in libertas + MMC support (instead of modules)
   cat >> ./.config << EOL
 CONFIG_LIBERTAS=y
 CONFIG_LIBERTAS_SDIO=y
+CONFIG_MMC_SDHCI=y
+CONFIG_MMC_SDHCI_ACPI=y
 CONFIG_BLK_CGROUP=y
 CONFIG_BLK_DEV_INITRD=y
 CONFIG_BLK_SCSI_REQUEST=y


### PR DESCRIPTION
After upgrading to 4.15+ kernels I've found that a few modules need to be built in to boot an Arch install from the inbuilt MMC.

These changes resolve this issue and the system now boots without any changes to mkinitcpio.conf 👍 

Related:
https://github.com/sigboe/GPD-ArchISO/pull/3