### PR TITLE
curl has to be able to follow redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ kring="$baseurl/njkli-keyring-20170902-1-any.pkg.tar.xz"
 kring_sig="$baseurl/njkli-keyring-20170902-1-any.pkg.tar.xz.sig"
 kring_files=("${kring}" "${kring_sig}")
 
-for i in ${kring_files[@]}; do curl -OfssL $i; done
+for i in ${kring_files[@]}; do curl -LOfssL $i; done
 
 gpg --keyserver hkp://keys.gnupg.net --recv-keys A09383D0550C42E2D6CE7C822F90CB4F042140DC
 gpg --verify njkli-keyring-20170902-1-any.pkg.tar.xz.sig


### PR DESCRIPTION
Because Github sometimes load-balances requests using HTTP 302 pointing to Amazon